### PR TITLE
Update ontrac regex

### DIFF
--- a/dist/tracking_number_data/couriers/ontrac.json
+++ b/dist/tracking_number_data/couriers/ontrac.json
@@ -4,7 +4,7 @@
     "tracking_numbers": [
         {
             "name": "OnTrac",
-            "regex": "\\s*C\\s*(?<SerialNumber>([0-9]\\s*){13})(?<CheckDigit>[0-9]\\s*)",
+            "regex": "\\s*[CD]\\s*(?<SerialNumber>([0-9]\\s*){13})(?<CheckDigit>[0-9]\\s*)",
             "validation": {
                 "checksum": {
                     "name": "mod10",
@@ -23,7 +23,8 @@
                 "valid": [
                     "C11031500001879",
                     " C 1 1 0 3 1 5 0 0 0 0 1 8 7 9 ",
-                    "C10999911320231"
+                    "C10999911320231",
+                    "D10999911320231"
                 ],
                 "invalid": [
                     "C10000000000000",


### PR DESCRIPTION
Ontrac have updated the regex to includes codes starting with a D.

Screenshots provided here from a recent Nike order of mine: 

<img width="704" alt="Screen Shot 2022-05-28 at 2 18 19 PM" src="https://user-images.githubusercontent.com/47309835/170843153-32c0c15e-66d5-44e1-b7b1-27ee5cbd1c95.png">

<img width="1042" alt="Screen Shot 2022-05-28 at 2 18 27 PM" src="https://user-images.githubusercontent.com/47309835/170843154-04361e78-cdf2-4a4e-ae16-1609e810231a.png">

